### PR TITLE
GH #22: almost integer nanoseconds needs forcing to integer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Fixed an issue with converting floating point second values to nanoseconds. These could be
+  converted to numbers which Perl stringified as an integer, but which really had a non-integer
+  component. Fixed by @n1vux (Bill Ricker). Fixes GH #14 via PR #15.
+
+
 0.16     2021-02-14
 
 - Add support for YYYYMMDDThhmm[+-]hhmm and YYYY-MM-DDThh:mm+hh:mm

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ author = Dave Rolsky <autarch@urth.org>
 license = Perl_5
 copyright_holder = Joshua Hoblitt
 
-; authordep Dist::Zilla::PluginBundle::DROLSKY = 1.18
+; authordep Dist::Zilla::PluginBundle::DROLSKY = 1.22
 [@DROLSKY]
 dist = DateTime-HiRes
 use_github_issues = 1

--- a/lib/DateTime/Format/ISO8601.pm
+++ b/lib/DateTime/Format/ISO8601.pm
@@ -1001,7 +1001,7 @@ sub _fractional_second {
     my %p = @_;
 
     ## no critic (ValuesAndExpressions::ProhibitMismatchedOperators)
-    $p{parsed}{nanosecond} = ".$p{ parsed }{ nanosecond }" * 10**9;
+    $p{parsed}{nanosecond} = int( ".$p{ parsed }{ nanosecond }" * 10**9 );
 
     return 1;
 }

--- a/t/datetime.t
+++ b/t/datetime.t
@@ -119,6 +119,12 @@ my @tests = (
         qw( YYYY-Www-DThh:mm+hh 1985-W15-5T10:15+04 1985-04-12T10:15:00 ),
         { time_zone => '+0400' }
     ],
+    [
+        # Expect for DT GH #145 HGuillemet = DTFI GH #22
+        qw( YYYYMMDDThhmmss.ssZ  2025-02-17T11:14:00.065341560Z ),
+        '2025-02-17T11:14:00',
+        { nanosecond => 65_341_560, time_zone => 'UTC', },
+    ],
 );
 
 subtest(


### PR DESCRIPTION
As noted in https://github.com/houseabsolute/DateTime.pm/issues/145 , https://github.com/houseabsolute/Specio/issues/22 , and #14  here,  a parse of an ISO8601 time string with 10ns precision would fail for presenting a floating `NUMBER` instead of an `INTEGER` as `nanosecond` to `DateTime->new()`.  
(The rescaling of the parsed fraction to nanoseconds would be exact in decimal arithmetic, but may have beyond-precision noise in binary; and this evaded detection previously.)

Fix is explicit `int()` of the re-scaling of parsed fraction into nanoseconds (with a test-first test); combined with `Specio` and `DateTime` patches today (_q.v._) to detect and reject very-nearly-integer floating point values for `PostitiveIntOrZero` declared types.

Thanks to @HGuillemet for great bug report and collaboration. Their ±10ns precision value that exposed this edge-case bug is used as the new test value.